### PR TITLE
Add music functionality to the bot

### DIFF
--- a/commands/pausemusic.js
+++ b/commands/pausemusic.js
@@ -1,0 +1,28 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { Player } = require('discord-music-player');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('pausemusic')
+        .setDescription('Pauses the currently playing music'),
+    async execute(interaction) {
+        const voiceChannel = interaction.member.voice.channel;
+
+        if (!voiceChannel) {
+            return interaction.reply('You need to be in a voice channel to pause music!');
+        }
+
+        const player = new Player(interaction.client, {
+            leaveOnEmpty: false,
+        });
+
+        const queue = player.getQueue(interaction.guild.id);
+
+        if (!queue || !queue.playing) {
+            return interaction.reply('There is no music currently playing!');
+        }
+
+        queue.setPaused(true);
+        await interaction.reply('Music has been paused.');
+    },
+};

--- a/commands/playmusic.js
+++ b/commands/playmusic.js
@@ -1,0 +1,37 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { Player } = require('discord-music-player');
+const { joinVoiceChannel } = require('@discordjs/voice');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('playmusic')
+        .setDescription('Plays music in a voice channel')
+        .addStringOption(option => 
+            option.setName('url')
+                .setDescription('The URL of the music to play')
+                .setRequired(true)),
+    async execute(interaction) {
+        const url = interaction.options.getString('url');
+        const voiceChannel = interaction.member.voice.channel;
+
+        if (!voiceChannel) {
+            return interaction.reply('You need to be in a voice channel to play music!');
+        }
+
+        const player = new Player(interaction.client, {
+            leaveOnEmpty: false,
+        });
+
+        const connection = joinVoiceChannel({
+            channelId: voiceChannel.id,
+            guildId: interaction.guild.id,
+            adapterCreator: interaction.guild.voiceAdapterCreator,
+        });
+
+        const song = await player.play(voiceChannel, url, {
+            requestedBy: interaction.user,
+        });
+
+        await interaction.reply(`Now playing: ${song.name}`);
+    },
+};

--- a/commands/queuemusic.js
+++ b/commands/queuemusic.js
@@ -1,0 +1,28 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { Player } = require('discord-music-player');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('queuemusic')
+        .setDescription('Shows the current music queue'),
+    async execute(interaction) {
+        const voiceChannel = interaction.member.voice.channel;
+
+        if (!voiceChannel) {
+            return interaction.reply('You need to be in a voice channel to view the music queue!');
+        }
+
+        const player = new Player(interaction.client, {
+            leaveOnEmpty: false,
+        });
+
+        const queue = player.getQueue(interaction.guild.id);
+
+        if (!queue || !queue.playing) {
+            return interaction.reply('There is no music currently playing!');
+        }
+
+        const queueString = queue.songs.map((song, index) => `${index + 1}. ${song.name}`).join('\n');
+        await interaction.reply(`Current music queue:\n${queueString}`);
+    },
+};

--- a/commands/skipmusic.js
+++ b/commands/skipmusic.js
@@ -1,0 +1,28 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { Player } = require('discord-music-player');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('skipmusic')
+        .setDescription('Skips the currently playing music'),
+    async execute(interaction) {
+        const voiceChannel = interaction.member.voice.channel;
+
+        if (!voiceChannel) {
+            return interaction.reply('You need to be in a voice channel to skip music!');
+        }
+
+        const player = new Player(interaction.client, {
+            leaveOnEmpty: false,
+        });
+
+        const queue = player.getQueue(interaction.guild.id);
+
+        if (!queue || !queue.playing) {
+            return interaction.reply('There is no music currently playing!');
+        }
+
+        queue.skip();
+        await interaction.reply('Skipped the current music.');
+    },
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@discordjs/builders": "^1.5.0",
         "@discordjs/rest": "^1.6.0",
         "axios": "^1.3.4",
-        "discord.js": "^14.8.0"
+        "discord.js": "^14.8.0",
+        "discord-music-player": "^8.3.0"
     }
 }


### PR DESCRIPTION
Related to #2

Add music functionality to the bot.

* **Add `discord-music-player` dependency**: Update `package.json` to include `discord-music-player` dependency.
* **Add play music command**: Create `commands/playmusic.js` to handle playing music in a voice channel.
* **Add pause music command**: Create `commands/pausemusic.js` to handle pausing the currently playing music.
* **Add skip music command**: Create `commands/skipmusic.js` to handle skipping the currently playing music.
* **Add queue music command**: Create `commands/queuemusic.js` to handle showing the current music queue.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/efrei-craft/efrei-craft-bot/issues/2?shareId=99b58975-a919-41bb-8875-308789ae073d).